### PR TITLE
encoder/decoder handle datetime obj

### DIFF
--- a/qiskit_ibm/runtime/utils.py
+++ b/qiskit_ibm/runtime/utils.py
@@ -22,6 +22,8 @@ import zlib
 import inspect
 import importlib
 import warnings
+from datetime import date
+import dateutil.parser
 
 import numpy as np
 try:
@@ -110,6 +112,8 @@ class RuntimeEncoder(json.JSONEncoder):
     """JSON Encoder used by runtime service."""
 
     def default(self, obj: Any) -> Any:  # pylint: disable=arguments-differ
+        if isinstance(obj, date):
+            return {'__type__': 'datetime', '__value__': obj.isoformat()}
         if isinstance(obj, complex):
             return {'__type__': 'complex', '__value__': [obj.real, obj.imag]}
         if isinstance(obj, np.ndarray):
@@ -167,6 +171,8 @@ class RuntimeDecoder(json.JSONDecoder):
             obj_type = obj['__type__']
             obj_val = obj['__value__']
 
+            if obj_type == 'datetime':
+                return dateutil.parser.parse(obj_val)
             if obj_type == 'complex':
                 return obj_val[0] + 1j * obj_val[1]
             if obj_type == 'ndarray':

--- a/releasenotes/notes/runtime-datetime-9dcc5a2d1e863436.yaml
+++ b/releasenotes/notes/runtime-datetime-9dcc5a2d1e863436.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    :class:`qiskit.providers.ibmq.runtime.utils.RuntimeEncoder` and 
+    :class:`qiskit.providers.ibmq.runtime.utils.RuntimeDecoder`
+    are updated to support Python ``datetime``, which is not 
+    JSON serializable by default

--- a/test/ibmq/runtime/test_runtime.py
+++ b/test/ibmq/runtime/test_runtime.py
@@ -23,6 +23,7 @@ import random
 import subprocess
 import tempfile
 import warnings
+from datetime import datetime
 import numpy as np
 import scipy.sparse
 
@@ -206,6 +207,19 @@ class TestRuntime(IBMQTestCase):
                 self.assertTrue(isinstance(decoded, opt_cls))
                 for key, value in settings.items():
                     self.assertEqual(decoded.settings[key], value)
+
+    def test_encoder_datetime(self):
+        """Test encoding a datetime."""
+        subtests = (
+            {"datetime": datetime.now()},
+            {"datetime": datetime(2021, 8, 4)},
+            {"datetime": datetime.fromtimestamp(1326244364)}
+        )
+        for obj in subtests:
+            encoded = json.dumps(obj, cls=RuntimeEncoder)
+            self.assertIsInstance(encoded, str)
+            decoded = json.loads(encoded, cls=RuntimeDecoder)
+            self.assertEqual(decoded, obj)
 
     def test_encoder_callable(self):
         """Test encoding a callable."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Python datetime is not serializable. This PR adds serializing/deserializing to the runtime encoder and decoder classes 

### Details and comments


