### PR TITLE
Update Runtime Programs

### DIFF
--- a/qiskit_ibm/api/clients/runtime.py
+++ b/qiskit_ibm/api/clients/runtime.py
@@ -106,6 +106,14 @@ class RuntimeClient:
         """
         return self.api.program(program_id).get_data()
 
+    def set_program_data(self, program_id: str, data: bytes) -> None:
+        """Sets a program's data.
+        Args:
+            program_id: Program ID.
+            data: Name of the program file or program data to upload.
+        """
+        self.api.program(program_id).set_data(data=data)
+
     def set_program_visibility(self, program_id: str, public: bool) -> None:
         """Sets a program's visibility.
 

--- a/qiskit_ibm/api/rest/runtime.py
+++ b/qiskit_ibm/api/rest/runtime.py
@@ -219,6 +219,14 @@ class Program(RestAdapterBase):
         url = self.get_url('data')
         return self.session.get(url).json()
 
+    def set_data(self, data: bytes) -> None:
+        """Set program information.
+        Args:
+            data: Name of the program file or program data to upload.
+        """
+        url = self.get_url('data')
+        self.session.put(url, data=data, headers={'content-type': 'text/plain'})
+
     def make_public(self) -> None:
         """Sets a runtime program's visibility to public."""
         url = self.get_url('public')

--- a/releasenotes/notes/add-update-program-059b591675994452.yaml
+++ b/releasenotes/notes/add-update-program-059b591675994452.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Updating a Qiskit Runtime program is now supported via:
+    :meth:`qiskit.providers.ibmq.IBMRuntimeService.update_program`.

--- a/test/ibmq/runtime/fake_runtime_client.py
+++ b/test/ibmq/runtime/fake_runtime_client.py
@@ -17,9 +17,9 @@ import uuid
 import json
 from concurrent.futures import ThreadPoolExecutor
 
-from qiskit_ibm.credentials import Credentials
-from qiskit_ibm.api.exceptions import RequestsApiError
-from qiskit_ibm.runtime.utils import RuntimeEncoder
+from qiskit.providers.ibmq.credentials import Credentials
+from qiskit.providers.ibmq.api.exceptions import RequestsApiError
+from qiskit.providers.ibmq.runtime.utils import RuntimeEncoder
 
 
 class BaseFakeProgram:
@@ -259,7 +259,7 @@ class BaseFakeRuntimeClient:
 
     def program_get_data(self, program_id: str):
         """Return a specific program and its data."""
-        return self._programs[program_id].to_dict(iclude_data=True)
+        return self._programs[program_id].to_dict(include_data=True)
 
     def program_run(
             self,
@@ -311,6 +311,15 @@ class BaseFakeRuntimeClient:
                 If ``False``, make the program visible to just your account.
         """
         self._programs[program_id]._is_public = public
+
+    def set_program_data(self, program_id: str, data: bytes) -> None:
+        """Sets a program's data.
+
+        Args:
+            program_id: Program ID.
+            data: Name of the program file or program data to upload.
+        """
+        self._programs[program_id]._data = data
 
     def job_results(self, job_id):
         """Get the results of a program job."""

--- a/test/ibmq/runtime/test_runtime.py
+++ b/test/ibmq/runtime/test_runtime.py
@@ -45,6 +45,7 @@ from qiskit.opflow import (PauliSumOp, MatrixOp, PauliOp, CircuitOp, EvolvedOp,
                            SparseVectorStateFn, CVaRMeasurement, ComposedOp, SummedOp, TensoredOp)
 from qiskit.quantum_info import SparsePauliOp, Pauli, PauliTable, Statevector
 from qiskit.providers.jobstatus import JobStatus
+from qiskit.exceptions import QiskitError
 
 from qiskit_ibm.exceptions import IBMQInputValueError
 from qiskit_ibm.accountprovider import AccountProvider
@@ -331,6 +332,31 @@ if __name__ == '__main__':
         params = self.runtime.program(program_id).parameters()
         params.param1 = "Hello World"
         self._run_program(program_id, inputs=params)
+
+    def test_program_upload_data_bytes(self):
+        """Test updating a program's string."""
+        program_id = self._upload_program()
+        self.runtime.update_program(program_id, 'print("Hello, Qiskit Provider.")'.encode())
+
+    def test_program_upload_data_filepath(self):
+        """Test updating a program's string."""
+        program_id = self._upload_program()
+        # Prepare file data
+        directory = os.path.dirname(__file__)
+        program_file_path = os.path.join(directory, "update-program-testfile.py")
+        program_file = open(program_file_path, "w+")
+        program_file.write('print("Hello, Qiskit Provider.")')
+        program_file.close()
+        # Update program
+        try:
+            self.runtime.update_program(program_id, program_file_path)
+            # Remove temp file
+            os.remove(program_file_path)
+        except QiskitError as err:
+            # Remove temp file
+            os.remove(program_file_path)
+            # Fail test
+            self.fail(err.message)
 
     def test_run_program_failed(self):
         """Test a failed program execution."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Qiskit Runtime supports an endpoint to update a runtime program, but the provider doesn't interface it yet.

### Details and comments

## Fixes #985 

- Allows a runtime program itself to be updated via `IBMRuntimeService.update_program()`

**Note:** The test could be better if it could verify the changed program string, but right now there is [not currently support](https://github.ibm.com/IBM-Q-Software/ntc/issues/534) for retrieving that plaintext program. (i.e there is no `GET program/{id}/data` counterpart to the `PUT` used in this PR)
