### PR TITLE
Specify program visibility with `is_public` parameter in `IBMRuntimeService.upload_program`

### DIFF
--- a/qiskit_ibm/api/clients/runtime.py
+++ b/qiskit_ibm/api/clients/runtime.py
@@ -53,6 +53,7 @@ class RuntimeClient:
             name: str,
             description: str,
             max_execution_time: int,
+            is_public: Optional[bool] = False,
             version: Optional[str] = None,
             backend_requirements: Optional[Dict] = None,
             parameters: Optional[Dict] = None,
@@ -66,6 +67,7 @@ class RuntimeClient:
             program_data: Program data.
             description: Program description.
             max_execution_time: Maximum execution time.
+            is_public: Whether the program should be public.
             version: Program version.
             backend_requirements: Backend requirements.
             parameters: Program parameters.
@@ -79,7 +81,7 @@ class RuntimeClient:
             program_data=program_data,
             name=name,
             description=description, max_execution_time=max_execution_time,
-            version=version, backend_requirements=backend_requirements,
+            is_public=is_public, version=version, backend_requirements=backend_requirements,
             parameters=parameters, return_values=return_values,
             interim_results=interim_results
         )

--- a/qiskit_ibm/api/rest/runtime.py
+++ b/qiskit_ibm/api/rest/runtime.py
@@ -69,6 +69,7 @@ class Runtime(RestAdapterBase):
             name: str,
             description: str,
             max_execution_time: int,
+            is_public: Optional[bool] = False,
             version: Optional[str] = None,
             backend_requirements: Optional[Dict] = None,
             parameters: Optional[Dict] = None,
@@ -82,6 +83,7 @@ class Runtime(RestAdapterBase):
             name: Name of the program.
             description: Program description.
             max_execution_time: Maximum execution time.
+            is_public: Whether the program should be public.
             version: Program version.
             backend_requirements: Backend requirements.
             parameters: Program parameters.
@@ -95,7 +97,8 @@ class Runtime(RestAdapterBase):
         data = {'name': name,
                 'cost': str(max_execution_time),
                 'description': description.encode(),
-                'max_execution_time': max_execution_time}
+                'max_execution_time': max_execution_time,
+                'isPublic': is_public}
         if version is not None:
             data['version'] = version
         if backend_requirements:

--- a/qiskit_ibm/runtime/ibm_runtime_service.py
+++ b/qiskit_ibm/runtime/ibm_runtime_service.py
@@ -253,6 +253,7 @@ class IBMRuntimeService:
             data: Union[bytes, str],
             metadata: Optional[Union[Dict, str]] = None,
             name: Optional[str] = None,
+            is_public: Optional[bool] = False,
             max_execution_time: Optional[int] = None,
             description: Optional[str] = None,
             version: Optional[float] = None,
@@ -287,6 +288,7 @@ class IBMRuntimeService:
             name: Name of the program. Required if not specified via `metadata`.
             max_execution_time: Maximum execution time in seconds. Required if
                 not specified via `metadata`.
+            is_public: Whether the runtime program should be visible to the public.
             description: Program description. Required if not specified via `metadata`.
             version: Program version. The default is 1.0 if not specified.
             backend_requirements: Backend requirements.
@@ -306,7 +308,8 @@ class IBMRuntimeService:
         program_metadata = self._merge_metadata(
             initial={},
             metadata=metadata,
-            name=name, max_execution_time=max_execution_time, description=description,
+            name=name, max_execution_time=max_execution_time,
+            is_public=is_public, description=description,
             version=version, backend_requirements=backend_requirements,
             parameters=parameters,
             return_values=return_values, interim_results=interim_results)
@@ -362,7 +365,7 @@ class IBMRuntimeService:
         # TODO validate metadata format
         metadata_keys = ['name', 'max_execution_time', 'description', 'version',
                          'backend_requirements', 'parameters', 'return_values',
-                         'interim_results']
+                         'interim_results', 'is_public']
         return {key: val for key, val in initial.items() if key in metadata_keys}
 
     def _tuple_to_dict(self, metadata: Dict) -> None:

--- a/qiskit_ibm/runtime/runtime_program.py
+++ b/qiskit_ibm/runtime/runtime_program.py
@@ -54,7 +54,7 @@ class RuntimeProgram:
             version: str = "0",
             backend_requirements: Optional[Dict] = None,
             creation_date: str = "",
-            is_public: bool = False
+            is_public: Optional[bool] = False
     ) -> None:
         """RuntimeProgram constructor.
 

--- a/releasenotes/notes/add-is_public-on-upload-program-5b5bb13912a8cf67.yaml
+++ b/releasenotes/notes/add-is_public-on-upload-program-5b5bb13912a8cf67.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    A runtime program's visibility can now be specified on upload
+    using `is_public` parameter in
+    :meth:`qiskit.providers.ibmq.IBMRuntimeService.upload_program`.

--- a/test/ibmq/runtime/fake_runtime_client.py
+++ b/test/ibmq/runtime/fake_runtime_client.py
@@ -48,7 +48,7 @@ class BaseFakeProgram:
                'cost': self._cost,
                'description': self._description,
                'version': self._version,
-               'is_public': self._is_public}
+               'isPublic': self._is_public}
         if include_data:
             out['data'] = self._data
         if self._backend_requirements:

--- a/test/ibmq/runtime/test_runtime.py
+++ b/test/ibmq/runtime/test_runtime.py
@@ -274,11 +274,14 @@ if __name__ == '__main__':
     def test_upload_program(self):
         """Test uploading a program."""
         max_execution_time = 3000
-        program_id = self._upload_program(max_execution_time=max_execution_time)
+        is_public = True
+        program_id = self._upload_program(max_execution_time=max_execution_time,
+                                          is_public=is_public)
         self.assertTrue(program_id)
         program = self.runtime.program(program_id)
         self.assertTrue(program)
         self.assertEqual(max_execution_time, program.max_execution_time)
+        self.assertEqual(program.is_public, is_public)
 
     def test_delete_program(self):
         """Test deleting program."""
@@ -583,13 +586,15 @@ if __name__ == '__main__':
         rjob = self.runtime.job(job.job_id())
         self.assertIsNotNone(rjob.backend())
 
-    def _upload_program(self, name=None, max_execution_time=300):
+    def _upload_program(self, name=None, max_execution_time=300,
+                        is_public: bool = False):
         """Upload a new program."""
         name = name or uuid.uuid4().hex
         data = "def main() {}"
         program_id = self.runtime.upload_program(
             name=name,
             data=data.encode(),
+            is_public=is_public,
             max_execution_time=max_execution_time,
             description="A test program")
         return program_id

--- a/test/ibmq/runtime/test_runtime_integration.py
+++ b/test/ibmq/runtime/test_runtime_integration.py
@@ -152,11 +152,14 @@ def main(backend, user_messenger, **kwargs):
     def test_upload_program(self):
         """Test uploading a program."""
         max_execution_time = 3000
-        program_id = self._upload_program(max_execution_time=max_execution_time)
+        is_public = True
+        program_id = self._upload_program(max_execution_time=max_execution_time,
+                                          is_public=is_public)
         self.assertTrue(program_id)
         program = self.provider.runtime.program(program_id)
         self.assertTrue(program)
         self.assertEqual(max_execution_time, program.max_execution_time)
+        self.assertEqual(program.is_public, is_public)
 
     def test_set_visibility(self):
         """Test setting the visibility of a program."""
@@ -583,12 +586,14 @@ def main(backend, user_messenger, **kwargs):
         self.assertTrue(program.creation_date)
         self.assertTrue(program.version)
 
-    def _upload_program(self, name=None, max_execution_time=300):
+    def _upload_program(self, name=None, max_execution_time=300,
+                        is_public: bool = False):
         """Upload a new program."""
         name = name or self._get_program_name()
         program_id = self.provider.runtime.upload_program(
             name=name,
             data=self.RUNTIME_PROGRAM.encode(),
+            is_public=is_public,
             metadata=self.RUNTIME_PROGRAM_METADATA,
             max_execution_time=max_execution_time,
             description="Qiskit test program")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds `is_public` as param for uploading runtime program.

### Details and comments

Fixes https://github.com/Qiskit/qiskit-ibmq-provider/issues/1006
