### PR TITLE
remove open pulse requirement in test_job_submission

### DIFF
--- a/test/ibmq/test_basic_server_paths.py
+++ b/test/ibmq/test_basic_server_paths.py
@@ -43,7 +43,7 @@ class TestBasicServerPaths(IBMQTestCase):
         """Test running a job against a device."""
         for desc, provider in self.providers.items():
             backend = least_busy(provider.backends(
-                simulator=False, open_pulse=False,
+                simulator=False,
                 filters=lambda b: b.configuration().n_qubits >= 5))
             with self.subTest(desc=desc, backend=backend):
                 job = self._submit_job_with_retry(ReferenceCircuits.bell(), backend)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #28 

test_job_submission test case was failing with 'Unable to find the least_busy backend from an empty list.' Since all backends have open pulse enabled, an empty list was always returned 

### Details and comments


