### PR TITLE
remove qobj backend run

### DIFF
--- a/test/ibmq/test_ibmq_qasm_simulator.py
+++ b/test/ibmq/test_ibmq_qasm_simulator.py
@@ -15,7 +15,7 @@
 from unittest import mock
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit.compiler import transpile, assemble
+from qiskit.compiler import transpile
 from qiskit.test.reference_circuits import ReferenceCircuits
 from qiskit.providers.aer.noise import NoiseModel
 

--- a/test/ibmq/test_ibmq_qasm_simulator.py
+++ b/test/ibmq/test_ibmq_qasm_simulator.py
@@ -133,8 +133,6 @@ class TestIbmqQasmSimulator(IBMQTestCase):
             backend._submit_job = _new_submit
             circ = transpile(ReferenceCircuits.bell(), backend=backend)
             backend.run(circ, header={'test': 'circuits'})
-            qobj = assemble(circ, backend=backend, header={'test': 'qobj'})
-            backend.run(qobj)
         finally:
             backend._configuration._data['simulation_method'] = sim_method
             backend._submit_job = submit_fn
@@ -156,8 +154,6 @@ class TestIbmqQasmSimulator(IBMQTestCase):
             backend._submit_job = _new_submit
             circ = transpile(ReferenceCircuits.bell(), backend=backend)
             backend.run(circ, method='my_method', header={'test': 'circuits'})
-            qobj = assemble(circ, backend=backend, method='my_method', header={'test': 'qobj'})
-            backend.run(qobj)
         finally:
             backend._configuration._data['simulation_method'] = sim_method
             backend._submit_job = submit_fn


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Passing a qobj to `backend.run` is deprecated - removing from these test cases

### Details and comments


