### PR TITLE
Fix IBMQJobManager job set retrieval

### DIFF
--- a/qiskit_ibm/managed/utils.py
+++ b/qiskit_ibm/managed/utils.py
@@ -25,7 +25,7 @@ from .managedjob import ManagedJob
 JOB_SET_NAME_FORMATTER = "{}_{}_"
 """Formatter for the name of a job in a job set. The first entry is the job set
 name, whereas the second entry is the job's index in the job set."""
-JOB_SET_NAME_RE = re.compile(r'(.*)_([0-9])+_$')
+JOB_SET_NAME_RE = re.compile(r'(.*)_([0-9]+)_$')
 """Regex used to match the name of a job in a job set. The first captured group is
 the job set name, whereas the second captured group is the job's index in the job set."""
 

--- a/releasenotes/notes/fix-jm-re-24d71126c0a2f539.yaml
+++ b/releasenotes/notes/fix-jm-re-24d71126c0a2f539.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes the issue where
+    :meth:`qiskit_ibm.managed.IBMQJobManager.retrieve_job_set` only
+    retrieves the first 10 jobs in a :class:`qiskit_ibm.managed.ManagedJobSet`.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #31. As reported in the issue, the regular expression used by Job Manager to find the correct job index was wrong and would only pick up the last digit. 

Note that this PR will be back ported to `qiskit-ibmq-provider` once merged. 
### Details and comments


