### PR TITLE
Remove accidental test

### DIFF
--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -454,17 +454,6 @@ class TestIBMQJobManager(IBMQTestCase):
                              .format(name, name, managed_results_params,
                                      name, result_params))
 
-    def test_double_digit_jobs(self):
-        """Test converting ManagedResult to Result."""
-        max_per_job = 1
-        job_set = self._jm.run([self._qc]*max_per_job*10, backend=self.fake_api_backend,
-                               max_experiments_per_job=max_per_job)
-        result_manager = job_set.results()
-        combined_result = result_manager.combine_results()
-
-        for i in range(max_per_job*2):
-            self.assertEqual(result_manager.get_counts(i), combined_result.get_counts(i))
-
     def _get_class_methods(self, cls):
         """Get public class methods from its namespace.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
#33 added a `test_double_digit_jobs` test case, which was meant to test a job set with double-digit jobs. That PR ended up just adding a subtest to `test_retrieve_job_set` to cover that scenario but forgot to delete the extra new test, which was never updated to actually test double digit jobs lol


### Details and comments


