### PR TITLE
Set jobs to empty list when backend widget is used in docs with a mock

### DIFF
--- a/qiskit_ibm/jupyter/jobs_widget.py
+++ b/qiskit_ibm/jupyter/jobs_widget.py
@@ -123,8 +123,11 @@ def _job_summary(backend: Union[IBMBackend, FakeBackend], **kwargs: Any) -> Plot
     limit = kwargs.pop('limit', None)
     start_datetime = kwargs.pop('start_datetime', past_year_date)
     provider = backend.provider()
-    jobs = provider.backend.jobs(backend_name=backend.name(),
-                                 limit=limit, start_datetime=start_datetime)
+    if not provider:
+        jobs = []  # provider will be None when this is used in docs
+    else:
+        jobs = provider.backend.jobs(backend_name=backend.name(),
+                                     limit=limit, start_datetime=start_datetime)
 
     num_jobs = len(jobs)
     main_str = "<b>Total Jobs</b><br>{}".format(num_jobs)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Set jobs to empty list when backend widget is used in docs with a mock, since `backend.provider()` will be None when used with a mock.


### Details and comments
Fixes #92 

