### PR TITLE
[Don't merge] Design PR for renaming configurable backend options

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,4 @@ project at different levels. If you use Qiskit, please cite as per the included
 [BibTeX file]: https://github.com/Qiskit/qiskit/blob/master/Qiskit.bib
 [Apache License 2.0]: https://github.com/Qiskit-Partners/qiskit-ibm/blob/main/LICENSE.txt
 [migration guide]: https://github.com/Qiskit-Partners/qiskit-ibm/blob/main/MIGRATING.md
+


### PR DESCRIPTION
This is a design PR for renaming configurable backend options to address issue #72.

# Issue Description
Currently configurable options do not follow any naming pattern. E.g. there is rep_delay and use_measure_esp, that are not unified in their naming.

There should be a unified naming convention used for configurable options, e.g. use_* or the like. These settings should then be returned in the job object as suggested in #71

# Solutions
## 1. Use Prefix
As suggested in the issue, use a prefix like `use_*`.

Pros:
1. Easy to see which options are configurable.

Cons:
1. Verbose, needs more typing
2. Doesn't read well when `use-*` is used with non boolean properties.
3. Breaking change for Circuit Jobs users

## 2. Use Options Class
We already have an `Options` class which represents the mutable backend options. We could consider renaming it to `BackendOptions` or `BackendConfig` or `BackendContext` or similar.

And then instead of passing bazillion parameters to `backend.run`, we could just pass the `BackendOptions` class.

```
backend_options = BackendOptions(shots=1024, memory=False,
                       qubit_lo_freq=None, meas_lo_freq=None,
                       schedule_los=None,
                       meas_level=MeasLevel.CLASSIFIED,
                       meas_return=MeasReturnType.AVERAGE,
                       memory_slots=None, memory_slot_size=100,
                       rep_time=None, rep_delay=None,
                       init_qubits=True, use_measure_esp=None)

backend.run(circuits, options)
```

Pros:
1. Easier to see which options are configurable.
2. Not verbose

Cons:
1. Breaking change for Circuit Jobs users

## 3. Leave Circuit Jobs as is, update only for Program Jobs
Waste no time changing this for Circuit Jobs (backend.run). Focus on getting this right for Program jobs (qiskit runtime). `runtime.run` already accepts an `options` Dict, which we could consider changing to a `BackendOptions` or `RuntimeOptions` class as suggested in Solution 2, or leave as Dict.

Pros:
1. Time saved not breaking Circuit Jobs users, and make it better for Program Jobs.
2. Easier to see which options are configurable.
2. Not verbose

Cons:
None that I could think of

My preference right now is Solution #3 - change options Dict to `BackendOptions` class only for Program Jobs (`runtime.run`).

@nonhermitian @jyu00 @ajavadia @mtreinish Thoughts?