### PR TITLE
Specify simulation method in test

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -157,7 +157,11 @@ def submit_job_one_bad_instr(backend: IBMBackend) -> IBMJob:
         Submitted job.
     """
     qc_new = transpile(ReferenceCircuits.bell(), backend)
-    qobj = assemble([qc_new]*2, backend=backend)
+    if backend.configuration().simulator:
+        # Specify method so it doesn't fail at method selection.
+        qobj = assemble([qc_new]*2, backend=backend, method="statevector")
+    else:
+        qobj = assemble([qc_new]*2, backend=backend)
     qobj.experiments[1].instructions[1].name = 'bad_instruction'
     job = backend._submit_job(qobj)
     return job


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #125. Per Matt's suggestion, this PR specifies a simulation method when using a simulator, so Aer doesn't fail when trying to pick a method. 


### Details and comments

Fixing this now instead of waiting for the new Aer to pass tests for my other PR :) 

