### PR TITLE
Check runtime job result cached by comparing to None

### DIFF
--- a/qiskit_ibm/runtime/runtime_job.py
+++ b/qiskit_ibm/runtime/runtime_job.py
@@ -104,7 +104,7 @@ class RuntimeJob:
         self._job_id = job_id
         self._backend = backend
         self._api_client = api_client
-        self._results = None
+        self._results: Optional[Any] = None
         self._params = params or {}
         self._creation_date = creation_date
         self._program_id = program_id
@@ -145,7 +145,7 @@ class RuntimeJob:
             RuntimeJobFailureError: If the job failed.
         """
         _decoder = decoder or self._result_decoder
-        if not self._results or (_decoder != self._result_decoder):  # type: ignore[unreachable]
+        if self._results is None or (_decoder != self._result_decoder):
             self.wait_for_final_state(timeout=timeout, wait=wait)
             if self._status == JobStatus.ERROR:
                 raise RuntimeJobFailureError(f"Unable to retrieve job result. "

--- a/releasenotes/notes/fix-runtime-numpy-result-7b096392ccd35718.yaml
+++ b/releasenotes/notes/fix-runtime-numpy-result-7b096392ccd35718.yaml
@@ -2,4 +2,4 @@
 fixes:
   - |
     Fixes the issue wherein a runtime job result cannot be retrieved multiple
-    time if the result contains a numpy array.
+    times if the result contains a numpy array.

--- a/releasenotes/notes/fix-runtime-numpy-result-7b096392ccd35718.yaml
+++ b/releasenotes/notes/fix-runtime-numpy-result-7b096392ccd35718.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the issue wherein a runtime job result cannot be retrieved multiple
+    time if the result contains a numpy array.

--- a/test/ibm/runtime/test_runtime.py
+++ b/test/ibm/runtime/test_runtime.py
@@ -572,6 +572,16 @@ if __name__ == '__main__':
                 result = job.result(decoder=decoder)
                 self.assertIsInstance(result['serializable_class'], SerializableClass)
 
+    def test_get_result_twice(self):
+        """Test getting results multiple times."""
+        custom_result = get_complex_types()
+        job_cls = CustomResultRuntimeJob
+        job_cls.custom_result = custom_result
+
+        job = self._run_program(job_classes=job_cls)
+        _ = job.result()
+        _ = job.result()
+
     def test_program_metadata(self):
         """Test program metadata."""
         file_name = "test_metadata.json"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #144.

Apparently if you simply do a `not <numpy array>`, numpy compares it to some zero value which may raise the `The truth value of an array with more than one element is ambiguous.` error. It just shows one really should be comparing to `None` instead of using `if not` when the expected value is `None`. 

### Details and comments


