### PR TITLE
Rename isPublic to is_public when creating or reading runtime programs

### DIFF
--- a/qiskit_ibm/api/rest/runtime.py
+++ b/qiskit_ibm/api/rest/runtime.py
@@ -96,7 +96,7 @@ class Runtime(RestAdapterBase):
                 'cost': str(max_execution_time),
                 'description': description.encode(),
                 'max_execution_time': max_execution_time,
-                'isPublic': is_public}
+                'is_public': is_public}
         if backend_requirements:
             data['backendRequirements'] = json.dumps(backend_requirements)
         if parameters:

--- a/qiskit_ibm/runtime/ibm_runtime_service.py
+++ b/qiskit_ibm/runtime/ibm_runtime_service.py
@@ -196,7 +196,7 @@ class IBMRuntimeService:
                               max_execution_time=response.get('cost', 0),
                               creation_date=response.get('creationDate', ""),
                               backend_requirements=backend_req,
-                              is_public=response.get('isPublic', False))
+                              is_public=response.get('is_public', False))
 
     def run(
             self,

--- a/test/ibm/runtime/fake_runtime_client.py
+++ b/test/ibm/runtime/fake_runtime_client.py
@@ -47,7 +47,7 @@ class BaseFakeProgram:
                'name': self._name,
                'cost': self._cost,
                'description': self._description,
-               'isPublic': self._is_public}
+               'is_public': self._is_public}
         if include_data:
             out['data'] = self._data
         if self._backend_requirements:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Rename isPublic to is_public when creating or reading runtime programs


### Details and comments
Fixes #154 

