### PR TITLE
Use runtime jobs count to reduce one last extra call to API

### DIFF
--- a/qiskit_ibm/runtime/ibm_runtime_service.py
+++ b/qiskit_ibm/runtime/ibm_runtime_service.py
@@ -508,17 +508,24 @@ class IBMRuntimeService:
         """
         job_responses = []  # type: List[Dict[str, Any]]
         current_page_limit = limit or 20
+        offset = skip
 
         while True:
-            job_page = self._api_client.jobs_get(
+            jobs_response = self._api_client.jobs_get(
                 limit=current_page_limit,
-                skip=skip,
-                pending=pending)["jobs"]
-            if not job_page:
+                skip=offset,
+                pending=pending)
+            job_page = jobs_response["jobs"]
+            # count is the total number of jobs that would be returned if
+            # there was no limit or skip
+            count = jobs_response["count"]
+
+            job_responses += job_page
+
+            if len(job_responses) == count - skip:
                 # Stop if there are no more jobs returned by the server.
                 break
 
-            job_responses += job_page
             if limit:
                 if len(job_responses) >= limit:
                     # Stop if we have reached the limit.
@@ -527,7 +534,7 @@ class IBMRuntimeService:
             else:
                 current_page_limit = 20
 
-            skip += len(job_page)
+            offset += len(job_page)
 
         return [self._decode_job(job) for job in job_responses]
 

--- a/test/ibm/runtime/fake_runtime_client.py
+++ b/test/ibm/runtime/fake_runtime_client.py
@@ -297,12 +297,14 @@ class BaseFakeRuntimeClient:
         limit = limit or len(self._jobs)
         skip = skip or 0
         jobs = list(self._jobs.values())
+        count = len(self._jobs)
         if pending is not None:
             job_status_list = pending_statuses if pending else returned_statuses
             jobs = [job for job in jobs if job._status in job_status_list]
+            count = len(jobs)
         jobs = jobs[skip:limit+skip]
         return {"jobs": [job.to_dict() for job in jobs],
-                "count": len(self._jobs)}
+                "count": count}
 
     def set_program_visibility(self, program_id: str, public: bool) -> None:
         """Sets a program's visibility.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Use runtime jobs `count` returned from API to reduce one last extra call when limit is `None`.
Didn't find a need to use `limit` and `offset` which was recently added in the runtime jobs API response.

### Details and comments
Fixes #147 

