### PR TITLE
Install qiskit-experiments from pypi

### DIFF
--- a/releasenotes/notes/require-qiskit-experiments-pip-8fdd9e20931bd3e7.yaml
+++ b/releasenotes/notes/require-qiskit-experiments-pip-8fdd9e20931bd3e7.yaml
@@ -1,6 +1,0 @@
----
-other:
-  - |
-    If using ``requirements-dev.txt``, ``qiskit-experiments`` will now
-    be installed from released versions on PyPI rather than from the ``main``
-    branch in the qiskit-experiments GitHub repository.

--- a/releasenotes/notes/require-qiskit-experiments-pip-8fdd9e20931bd3e7.yaml
+++ b/releasenotes/notes/require-qiskit-experiments-pip-8fdd9e20931bd3e7.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  - |
+    If using ``requirements-dev.txt``, ``qiskit-experiments`` will now
+    be installed from released versions on PyPI rather than from the ``main``
+    branch in the qiskit-experiments GitHub repository.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,5 +25,4 @@ qiskit_rng
 qiskit-aer
 websockets>=8
 scikit-quant;platform_system != 'Windows'
-# TODO: Use released qiskit-experiments when it's released
-git+https://github.com/Qiskit/qiskit-experiments.git ; python_version > '3.6'
+qiskit-experiments; python_version > '3.6'


### PR DESCRIPTION

### Summary

qiskit-experiments 0.1.0 was released on Aug 2, 2021. Per
the TODO we should be using that now.

### Details and comments

I ran all of the experiments integration tests with this and they
passed. Note that #210 will need to be fixed before the next
qiskit-experiments release.
