### PR TITLE
Cleanup experiment from test_set_service_job

### DIFF
--- a/test/ibm/experiment/test_experiment_data_integration.py
+++ b/test/ibm/experiment/test_experiment_data_integration.py
@@ -329,6 +329,7 @@ class TestExperimentDataIntegration(IBMTestCase):
         job = self._run_circuit()
         exp_data.add_data(job)
         exp_data.save()
+        self.experiments_to_delete.append(exp_data.experiment_id)
 
         rexp = self.experiment.experiment(exp_data.experiment_id)
         self.assertEqual([job.job_id()], rexp["job_ids"])


### PR DESCRIPTION

### Summary

The experiment created in `test_set_service_job` is not
using the `_create_experiment_data` helper so it was not
being cleaned up during `tearDown`. It's not clear to me
if `_create_experiment_data` _should_ be used in this test
so for this fix I just add the experiment ID directly to
`self.experiments_to_delete`.

### Details and comments

Closes #67
