### PR TITLE
Compare sorted tags in test_save_all

### DIFF
--- a/test/ibm/experiment/test_experiment_data_integration.py
+++ b/test/ibm/experiment/test_experiment_data_integration.py
@@ -310,7 +310,9 @@ class TestExperimentDataIntegration(IBMTestCase):
         exp_data.save()
 
         rexp = DbExperimentData.load(exp_data.experiment_id, self.experiment)
-        self.assertEqual(["foo", "bar"], rexp.tags)
+        # Experiment tag order is not necessarily preserved by qiskit-experiments
+        # so compare tags with a predictable sort order.
+        self.assertEqual(["bar", "foo"], sorted(rexp.tags))
         self.assertEqual(aresult.result_id, rexp.analysis_results(0).result_id)
         self.assertEqual(hello_bytes, rexp.figure(0))
 


### PR DESCRIPTION

### Summary

qiskit-experiments does not maintain order on experiment
tags since [1] so we need to compare experiment tags in
the `test_save_all` test with a predictable sort order.

[1] https://github.com/Qiskit/qiskit-experiments/pull/522


### Details and comments

Closes #210
