### PR TITLE
Support filtering analysis_results by created_at

### DIFF
--- a/qiskit_ibm/api/clients/experiment.py
+++ b/qiskit_ibm/api/clients/experiment.py
@@ -230,6 +230,7 @@ class ExperimentClient(BaseClient):
             quality: Optional[Union[str, List[str]]] = None,
             verified: Optional[bool] = None,
             tags: Optional[List[str]] = None,
+            created_at: Optional[List] = None,
             sort_by: Optional[str] = None
     ) -> str:
         """Return a list of analysis results.
@@ -244,6 +245,7 @@ class ExperimentClient(BaseClient):
             quality: Quality value used for filtering.
             verified: Indicates whether this result has been verified.
             tags: Filter by tags assigned to analysis results.
+            created_at: A list of timestamps used to filter by creation time.
             sort_by: Indicates how the output should be sorted.
 
         Returns:
@@ -259,6 +261,7 @@ class ExperimentClient(BaseClient):
             quality=quality,
             verified=verified,
             tags=tags,
+            created_at=created_at,
             sort_by=sort_by
         )
         return resp

--- a/qiskit_ibm/api/rest/root.py
+++ b/qiskit_ibm/api/rest/root.py
@@ -260,6 +260,7 @@ class Api(RestAdapterBase):
             quality: Optional[List[str]] = None,
             verified: Optional[bool] = None,
             tags: Optional[List[str]] = None,
+            created_at: Optional[List] = None,
             sort_by: Optional[str] = None
     ) -> str:
         """Return all analysis results.
@@ -274,6 +275,7 @@ class Api(RestAdapterBase):
             quality: Quality value used for filtering.
             verified: Indicates whether this result has been verified.
             tags: Filter by tags assigned to analysis results.
+            created_at: A list of timestamps used to filter by creation time.
             sort_by: Indicates how the output should be sorted.
 
         Returns:
@@ -299,6 +301,8 @@ class Api(RestAdapterBase):
             params["verified"] = "true" if verified else "false"
         if tags:
             params['tags'] = tags
+        if created_at:
+            params['created_at'] = created_at
         if sort_by:
             params['sort'] = sort_by
         return self.session.get(url, params=params).text

--- a/releasenotes/notes/filter-analysis-results-by-created-at-b8888dbb13ede477.yaml
+++ b/releasenotes/notes/filter-analysis-results-by-created-at-b8888dbb13ede477.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Analysis results can now be filtered by ``creation_datetime_after`` and
+    ``creation_datetime_before`` in 
+    :meth:`qiskit_ibm.experiment.IBMExperimentService.analysis_results`.


### PR DESCRIPTION

### Summary

Version 0.44.0 of the experiments API supports filtering
analysis results by the `created_at` field in the
`GET /analysis_results` endpoint. This adds that support
to `IBMExperimentService.analysis_results`. The same pattern
for filtering experiments by `start_time` is used here.

### Details and comments

Some old or incorrect docstrings are also updated.

Closes #215
