### PR TITLE
Remove assert logs from invalid proxy port test case

### DIFF
--- a/test/ibm/runtime/test_runtime_integration.py
+++ b/test/ibm/runtime/test_runtime_integration.py
@@ -667,11 +667,12 @@ def main(backend, user_messenger, **kwargs):
         callback_called = False
         invalid_proxy = {'https': 'http://{}:{}'.format(MockProxyServer.PROXY_IP_ADDRESS,
                                                         MockProxyServer.INVALID_PROXY_PORT)}
+
+        # TODO - verify WebsocketError in output log. For some reason self.assertLogs
+        # doesn't always work even when the error is clearly logged.
         with use_proxies(self.provider, invalid_proxy):
-            with self.assertLogs('qiskit_ibm', 'WARNING') as log_cm:
-                job = self._run_program(iterations=1, callback=result_callback)
-                job.wait_for_final_state()
-            self.assertIn("WebsocketError", ','.join(log_cm.output))
+            job = self._run_program(iterations=1, callback=result_callback)
+            job.wait_for_final_state()
         self.assertFalse(callback_called)
 
     def test_job_logs(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

fixes #203 

Assert logs does not always pick up the logs from the websocket error 

### Details and comments


