### PR TITLE
Enable additional integration test cases (test_account_client)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         python-version: [ 3.9 ]
         os: [ "ubuntu-latest" ]
-        environment: [ "legacy-production" ]
+        environment: [ "legacy-production", "legacy-staging" ]
     environment: ${{ matrix.environment }}
     env:
       QISKIT_IBM_TOKEN: ${{ secrets.QISKIT_IBM_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ unit-test-coverage:
 
 integration-test:
 	# TODO: enable all tests in "test/integration" directory
-	python -m unittest -v test/integration/test_backend.py
+	python -m unittest -v test/integration/test_backend.py test/integration/test_account_client.py
 
 black:
 	black qiskit_ibm_provider test setup.py docs/tutorials

--- a/qiskit_ibm_provider/ibm_provider.py
+++ b/qiskit_ibm_provider/ibm_provider.py
@@ -170,9 +170,9 @@ class IBMProvider(Provider):
             proxies=self._account.proxies,
             verify=self._account.verify,
         )
-        auth_client = self._authenticate_legacy_account(self._client_params)
+        self._auth_client = self._authenticate_legacy_account(self._client_params)
 
-        self._hgps = self._initialize_hgps(auth_client)
+        self._hgps = self._initialize_hgps(self._auth_client)
         self._initialize_services()
 
     @staticmethod


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixed next set of integration tests. Enabled integration tests to run against `legacy-staging` on a nightly basis.


### Details and comments
Relates to changes triggered by https://github.com/Qiskit/qiskit-ibm-provider/issues/237. Follow-up of https://github.com/Qiskit/qiskit-ibm-provider/pull/259.

