### PR TITLE
Run unit tests against terra main

### DIFF
--- a/.github/workflows/unit-tests-terra-main.yml
+++ b/.github/workflows/unit-tests-terra-main.yml
@@ -1,0 +1,43 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+name: Unit Tests
+on:
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+jobs:
+  unit-tests-latest-qiskit-terra:
+    name: Run unit tests with latest code of qiskit-terra
+    runs-on: "ubuntu-latest"
+    env:
+      LOG_LEVEL: DEBUG
+      STREAM_LOG: True
+      QISKIT_IN_PARALLEL: True
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -c constraints.txt -e .
+          pip install -U -c constraints.txt -r requirements-dev.txt
+          pip install -U git+https://github.com/Qiskit/qiskit-terra.git
+      - name: Run tests
+        # running unit tests against latest (non-released) code of qiskit-terra gives a basic level
+        # of confidence that the integration between qiskit-ibm-provider and qiskit-terra works
+        run: make unit-test


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Run unit tests against terra main nightly so we can learn about upcoming breaking changes in terra early. This replaces the [terra master slow tests](https://github.com/Qiskit/qiskit-ibmq-provider/runs/6073586469?check_suite_focus=true) from qiskit-ibmq-provider.


### Details and comments


