### PR TITLE
Fix unit websocket tests

### DIFF
--- a/test/unit/test_websocket.py
+++ b/test/unit/test_websocket.py
@@ -35,7 +35,7 @@ from ..ibm_test_case import IBMTestCase
 from ..ws_server import MockWsServer
 
 
-class TestWebsocketClient(IBMTestCase):
+class TestWebsocketClientThreading(IBMTestCase):
     """Tests for the websocket client."""
 
     def test_invalid_url(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`setUpClass` in `TestWebsocketClientMock` in the unit tests against terra are failing [here](https://github.com/Qiskit/qiskit-ibm-provider/runs/6114436881?check_suite_focus=true#step:5:296). I wasn't able to replicate the error locally but I believe the `test_threading` test [here](https://github.com/Qiskit/qiskit-ibm-provider/blob/main/test/unit/test_websocket.py#L50) is blocking the server start - a simple solution would just be to switch the order of the tests

the tests are passing in my [fork](https://github.com/kt474/qiskit-ibm/runs/6117630118?check_suite_focus=true)

### Details and comments


