### PR TITLE
Remove services related methods since there is only one service, the backend service

### DIFF
--- a/qiskit_ibm_provider/ibm_provider.py
+++ b/qiskit_ibm_provider/ibm_provider.py
@@ -28,7 +28,6 @@ from .api.clients import AuthClient, VersionClient
 from .apiconstants import QISKIT_IBM_API_URL
 from .exceptions import IBMAccountError
 from .exceptions import (
-    IBMNotAuthorizedError,
     IBMInputValueError,
 )
 from .hub_group_project import HubGroupProject  # pylint: disable=cyclic-import
@@ -84,14 +83,12 @@ class IBMProvider(Provider):
         * A premium hub/group/project in your account.
         * An open access hub/group/project.
 
-    The IBMProvider offers different services. The main service,
-    :class:`~qiskit_ibm_provider.ibm_backend_service.IBMBackendService` gives access to IBM Quantum
-    devices and simulators.
+    The IBMProvider offers the :class:`~qiskit_ibm_provider.ibm_backend_service.IBMBackendService`
+    which gives access to the IBM Quantum devices and simulators.
 
-    You can obtain an instance of a service using the :meth:`service()` method
-    or as an attribute of this ``IBMProvider`` instance. For example::
+    You can obtain an instance of the service as an attribute of the ``IBMProvider`` instance.
+    For example::
 
-        backend_service = provider.service('backend')
         backend_service = provider.backend
 
     Since :class:`~qiskit_ibm_provider.ibm_backend_service.IBMBackendService`
@@ -573,52 +570,6 @@ class IBMProvider(Provider):
         if not backends:
             raise QiskitBackendNotFoundError("No backend matches the criteria")
         return backends[0]
-
-    def has_service(self, name: str) -> bool:
-        """Check if this account has access to the service.
-
-        Args:
-            name: Name of the service.
-
-        Returns:
-            Whether the account has access to the service.
-
-        Raises:
-            IBMInputValueError: If an unknown service name is specified.
-        """
-        if name not in self._services:
-            raise IBMInputValueError(f"Unknown service {name} specified.")
-        if self._services[name] is None:
-            return False
-        return True
-
-    def service(self, name: str) -> Any:
-        """Return the specified service.
-
-        Args:
-            name: Name of the service.
-
-        Returns:
-            The specified service.
-
-        Raises:
-            IBMInputValueError: If an unknown service name is specified.
-            IBMNotAuthorizedError: If the account is not authorized to use
-                the service.
-        """
-        if name not in self._services:
-            raise IBMInputValueError(f"Unknown service {name} specified.")
-        if self._services[name] is None:
-            raise IBMNotAuthorizedError("You are not authorized to use this service.")
-        return self._services[name]
-
-    def services(self) -> Dict:
-        """Return all available services.
-
-        Returns:
-            All services available to this account.
-        """
-        return {key: val for key, val in self._services.items() if val is not None}
 
     def __repr__(self) -> str:
         return "<{}>".format(self.__class__.__name__)

--- a/test/integration/test_ibm_provider.py
+++ b/test/integration/test_ibm_provider.py
@@ -269,12 +269,6 @@ class TestIBMProviderServices(IBMTestCase):
         }
         self.assertEqual(backend_attributes, backends)
 
-    def test_provider_services(self):
-        """Test provider services."""
-        services = self.dependencies.provider.services()
-        self.assertIn("backend", services)
-        self.assertIsInstance(services["backend"], IBMBackendService)
-        self.assertIsInstance(
-            self.dependencies.provider.service("backend"), IBMBackendService
-        )
+    def test_provider_has_backend_service(self):
+        """Test provider has backend service."""
         self.assertIsInstance(self.dependencies.provider.backend, IBMBackendService)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Backend service can be accessed using `provider.backend`


### Details and comments


