### PR TITLE
Make `provider.backend.jobs()` account level

### DIFF
--- a/qiskit_ibm_provider/api/clients/account.py
+++ b/qiskit_ibm_provider/api/clients/account.py
@@ -152,7 +152,7 @@ class AccountClient(BaseClient):
 
     # Jobs-related public functions.
 
-    def list_jobs_statuses(
+    def list_jobs(
         self,
         limit: int = 10,
         skip: int = 0,
@@ -173,7 +173,7 @@ class AccountClient(BaseClient):
         Returns:
             A list of job data.
         """
-        return self.account_api.jobs(
+        return self.base_api.jobs(
             limit=limit, skip=skip, descending=descending, extra_filter=extra_filter
         )
 

--- a/qiskit_ibm_provider/api/rest/account.py
+++ b/qiskit_ibm_provider/api/rest/account.py
@@ -22,7 +22,6 @@ from .base import RestAdapterBase
 from .backend import Backend
 from .job import Job
 from ..session import RetrySession
-from .utils.data_mapper import map_job_response
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +32,6 @@ class Account(RestAdapterBase):
     URL_MAP = {
         "backends": "/devices/v/1",
         "jobs": "/Jobs",
-        "jobs_status": "/Jobs/status/v/1",
         "jobs_id": "/Jobs/v/1",
     }
 
@@ -94,47 +92,6 @@ class Account(RestAdapterBase):
         """
         url = self.get_url("backends")
         return self.session.get(url, timeout=timeout).json()
-
-    def jobs(
-        self,
-        limit: int = 10,
-        skip: int = 0,
-        descending: bool = True,
-        extra_filter: Dict[str, Any] = None,
-    ) -> List[Dict[str, Any]]:
-        """Return a list of job information.
-
-        Args:
-            limit: Maximum number of items to return.
-            skip: Offset for the items to return.
-            descending: Whether the jobs should be in descending order.
-            extra_filter: Additional filtering passed to the query.
-
-        Returns:
-            JSON response.
-        """
-        url = self.get_url("jobs_status")
-        order = "DESC" if descending else "ASC"
-
-        query = {
-            "order": "creationDate " + order,
-            "limit": limit,
-            "skip": skip,
-        }
-        if extra_filter:
-            query["where"] = extra_filter
-
-        if logger.getEffectiveLevel() is logging.DEBUG:
-            logger.debug(
-                "Endpoint: %s. Method: GET. Request Data: {'filter': %s}",
-                url,
-                filter_data(query),
-            )
-
-        data = self.session.get(url, params={"filter": json.dumps(query)}).json()
-        for job_data in data:
-            map_job_response(job_data)
-        return data
 
     def jobs_ids(
         self,

--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -47,7 +47,6 @@ from qiskit.transpiler.target import Target
 from qiskit_ibm_provider import ibm_provider  # pylint: disable=unused-import
 from .api.clients import AccountClient
 from .api.exceptions import ApiError
-from .apiconstants import ApiJobStatus, API_JOB_FINAL_STATES
 from .backendjoblimit import BackendJobLimit
 from .backendreservation import BackendReservation
 from .exceptions import (
@@ -65,7 +64,6 @@ from .utils.backend_converter import (
 )
 from .utils.converters import local_to_utc
 from .utils.json_decoder import defaults_from_server_data, properties_from_server_data
-from .utils.utils import api_status_to_job_status
 
 logger = logging.getLogger(__name__)
 
@@ -817,16 +815,7 @@ class IBMBackend(Backend):
         Returns:
             A list of the unfinished jobs for this backend on this provider.
         """
-        # Get the list of api job statuses which are not a final api job status.
-        active_job_states = list(
-            {
-                api_status_to_job_status(status)
-                for status in ApiJobStatus
-                if status not in API_JOB_FINAL_STATES
-            }
-        )
-        provider = self.provider
-        return provider.backend.jobs(status=active_job_states, limit=limit)
+        return self.provider.backend.jobs(status="pending", limit=limit)
 
     def reservations(
         self,

--- a/qiskit_ibm_provider/ibm_backend_service.py
+++ b/qiskit_ibm_provider/ibm_backend_service.py
@@ -16,6 +16,7 @@ import copy
 import logging
 from datetime import datetime
 from typing import Dict, List, Callable, Optional, Any, Union
+from typing_extensions import Literal
 
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit.providers.jobstatus import JobStatus
@@ -170,14 +171,14 @@ class IBMBackendService:
         limit: Optional[int] = 10,
         skip: int = 0,
         backend_name: Optional[str] = None,
-        status: Optional[Union[JobStatus, str, List[Union[JobStatus, str]]]] = None,
+        status: Optional[Literal["pending", "completed"]] = None,
         job_name: Optional[str] = None,
         start_datetime: Optional[datetime] = None,
         end_datetime: Optional[datetime] = None,
         job_tags: Optional[List[str]] = None,
-        job_tags_operator: Optional[str] = "OR",
         descending: bool = True,
         ignore_composite_jobs: bool = False,
+        instance: Optional[str] = None,
     ) -> List[IBMJob]:
         """Return a list of jobs, subject to optional filtering.
 
@@ -190,9 +191,7 @@ class IBMBackendService:
             limit: Number of jobs to retrieve. ``None`` means no limit.
             skip: Starting index for the job retrieval.
             backend_name: Name of the backend to retrieve jobs from.
-            status: Only get jobs with this status or one of the statuses.
-                For example, you can specify `status=JobStatus.RUNNING` or `status="RUNNING"`
-                or `status=["RUNNING", "ERROR"]`
+            status: Filter jobs with with either "pending" or "completed" status.
             job_name: Filter by job name. The `job_name` is matched partially
                 and `regular expressions
                 <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions>`_
@@ -203,19 +202,13 @@ class IBMBackendService:
             end_datetime: Filter by the given end date, in local time. This is used to
                 find jobs whose creation dates are before (less than or equal to) this
                 local date/time.
-            job_tags: Filter by tags assigned to jobs.
-            job_tags_operator: Logical operator to use when filtering by job tags. Valid
-                values are "AND" and "OR":
-
-                    * If "AND" is specified, then a job must have all of the tags
-                      specified in ``job_tags`` to be included.
-                    * If "OR" is specified, then a job only needs to have any
-                      of the tags specified in ``job_tags`` to be included.
+            job_tags: Filter by tags assigned to jobs. Matched jobs are associated with all tags.
             descending: If ``True``, return the jobs in descending order of the job
                 creation date (i.e. newest first) until the limit is reached.
             ignore_composite_jobs: If ``True``, sub-jobs of a single
                 :class:`~qiskit_ibm_provider.job.IBMCompositeJob` will be
                 returned as individual jobs instead of merged together.
+            instance: The provider in the hub/group/project format.
 
         Returns:
             A list of ``IBMJob`` instances.
@@ -228,35 +221,20 @@ class IBMBackendService:
         # Build the filter for the query.
         api_filter = {}  # type: Dict[str, Any]
         if backend_name:
-            api_filter["backend.name"] = backend_name
+            api_filter["backend"] = backend_name
         if status:
-            status_filter = self._get_status_db_filter(status)
-            api_filter.update(status_filter)
+            api_filter["status"] = status
         if job_name:
-            api_filter["name"] = {"regexp": job_name}
-        if start_datetime or end_datetime:
-            api_filter["creationDate"] = self._update_creation_date_filter(
-                cur_dt_filter={},
-                gte_dt=local_to_utc(start_datetime).isoformat()
-                if start_datetime
-                else None,
-                lte_dt=local_to_utc(end_datetime).isoformat() if end_datetime else None,
-            )
+            api_filter["search"] = job_name
+        if start_datetime:
+            api_filter["createdAfter"] = local_to_utc(start_datetime).isoformat()
+        if end_datetime:
+            api_filter["createdBefore"] = local_to_utc(end_datetime).isoformat()
         if job_tags:
             validate_job_tags(job_tags, IBMBackendValueError)
-            job_tags_operator = job_tags_operator.upper()
-            if job_tags_operator == "OR":
-                api_filter["tags"] = {"inq": job_tags}
-            elif job_tags_operator == "AND":
-                and_tags = []
-                for tag in job_tags:
-                    and_tags.append({"tags": tag})
-                api_filter["and"] = and_tags
-            else:
-                raise IBMBackendValueError(
-                    '"{}" is not a valid job_tags_operator value. '
-                    'Valid values are "AND" and "OR"'.format(job_tags_operator)
-                )
+            api_filter["tags"] = job_tags
+        if instance:
+            api_filter["provider"] = instance
         # Retrieve all requested jobs.
         job_responses = self._get_jobs(
             api_filter=api_filter, limit=limit, skip=skip, descending=descending
@@ -307,10 +285,9 @@ class IBMBackendService:
         # Retrieve the requested number of jobs, using pagination. The server
         # might limit the number of jobs per request.
         job_responses: List[Dict[str, Any]] = []
-        current_page_limit = limit or 20
-        initial_filter = copy.deepcopy(api_filter)
+        current_page_limit = limit if (limit is not None and limit <= 50) else 50
         while True:
-            job_page = self._default_hgp._api_client.list_jobs_statuses(
+            job_page = self._default_hgp._api_client.list_jobs(
                 limit=current_page_limit,
                 skip=skip,
                 descending=descending,
@@ -329,37 +306,8 @@ class IBMBackendService:
                     break
                 current_page_limit = limit - len(job_responses)
             else:
-                current_page_limit = 20
-            # Use the last received job for pagination.
-            skip = 0
-            last_job = job_page[-1]
-            api_filter = copy.deepcopy(initial_filter)
-            cur_dt_filter = api_filter.pop("creationDate", {})
-            if descending:
-                new_dt_filter = self._update_creation_date_filter(
-                    cur_dt_filter=cur_dt_filter, lte_dt=last_job["creation_date"]
-                )
-            else:
-                new_dt_filter = self._update_creation_date_filter(
-                    cur_dt_filter=cur_dt_filter, gte_dt=last_job["creation_date"]
-                )
-            if not cur_dt_filter:
-                api_filter["creationDate"] = new_dt_filter
-            else:
-                self._merge_logical_filters(
-                    api_filter,
-                    {"and": [{"creationDate": new_dt_filter}, cur_dt_filter]},
-                )
-            if "id" not in api_filter:
-                api_filter["id"] = {"nin": [last_job["job_id"]]}
-            else:
-                new_id_filter = {
-                    "and": [
-                        {"id": {"nin": [last_job["job_id"]]}},
-                        {"id": api_filter.pop("id")},
-                    ]
-                }
-                self._merge_logical_filters(api_filter, new_id_filter)
+                current_page_limit = 50
+            skip = len(job_responses)
         return job_responses
 
     def _restore_circuit_job(

--- a/qiskit_ibm_provider/ibm_backend_service.py
+++ b/qiskit_ibm_provider/ibm_backend_service.py
@@ -191,7 +191,7 @@ class IBMBackendService:
             limit: Number of jobs to retrieve. ``None`` means no limit.
             skip: Starting index for the job retrieval.
             backend_name: Name of the backend to retrieve jobs from.
-            status: Filter jobs with with either "pending" or "completed" status.
+            status: Filter jobs with either "pending" or "completed" status.
             job_name: Filter by job name. The `job_name` is matched partially
                 and `regular expressions
                 <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions>`_

--- a/qiskit_ibm_provider/job/ibm_job.py
+++ b/qiskit_ibm_provider/job/ibm_job.py
@@ -257,3 +257,6 @@ class IBMJob(Job, ABC):
             The Qobj for this job, or ``None`` if the job does not have a Qobj.
         """
         pass
+
+    def __repr__(self) -> str:
+        return "<{}('{}')>".format(self.__class__.__name__, self.job_id())

--- a/test/fake_account_client.py
+++ b/test/fake_account_client.py
@@ -349,8 +349,8 @@ class BaseFakeAccountClient:
         self._run_mode = run_mode
         self._default_job_class = BaseFakeJob
 
-    def list_jobs_statuses(self, limit, skip, descending=True, extra_filter=None):
-        """Return a list of statuses of jobs."""
+    def list_jobs(self, limit, skip, descending=True, extra_filter=None):
+        """Return a list of jobs."""
         # pylint: disable=unused-argument
         extra_filter = extra_filter or {}
         if all(fil in extra_filter for fil in ["creationDate", "id"]):

--- a/test/integration/test_account_client.py
+++ b/test/integration/test_account_client.py
@@ -204,12 +204,12 @@ class TestAccountClientJobs(IBMTestCase):
         self.assertEqual(response.pop("status", None), ApiJobStatus.COMPLETED.value)
         self.assertNotEqual(status_queue.qsize(), 0)
 
-    def test_list_jobs_statuses_skip(self):
-        """Test listing job statuses with an offset."""
-        jobs_raw = self.client.list_jobs_statuses(
+    def test_list_jobs_skip(self):
+        """Test listing jobs with an offset."""
+        jobs_raw = self.client.list_jobs(
             limit=1,
             skip=1,
-            extra_filter={"creationDate": {"lte": self.job["creation_date"]}},
+            extra_filter={"createdBefore": self.job["creation_date"]},
         )
 
         # Ensure our job is skipped

--- a/test/integration/test_ibm_job_attributes.py
+++ b/test/integration/test_ibm_job_attributes.py
@@ -397,34 +397,8 @@ class TestIBMJobAttributes(IBMTestCase):
             delattr(self.sim_backend._configuration, "measure_esp_enabled")
             self.sim_backend._api_client = saved_api
 
-    def test_job_tags_or(self):
-        """Test using job tags with an or operator."""
-        # Use a unique tag.
-        job_tags = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
-        job = self.sim_backend.run(self.bell, job_tags=job_tags)
-
-        rjobs = self.dependencies.provider.backend.jobs(
-            job_tags=["phantom_tag"], start_datetime=self.last_week
-        )
-        self.assertEqual(
-            len(rjobs), 0, "Expected job {}, got {}".format(job.job_id(), rjobs)
-        )
-
-        # Check all tags, some of the tags, and a mixture of good and bad tags.
-        tags_to_check = [job_tags, job_tags[1:2], job_tags[0:1] + ["phantom_tag"]]
-        for tags in tags_to_check:
-            with self.subTest(tags=tags):
-                rjobs = self.dependencies.provider.backend.jobs(
-                    job_tags=tags, start_datetime=self.last_week
-                )
-                self.assertEqual(
-                    len(rjobs), 1, "Expected job {}, got {}".format(job.job_id(), rjobs)
-                )
-                self.assertEqual(rjobs[0].job_id(), job.job_id())
-                self.assertEqual(set(rjobs[0].tags()), set(job_tags))
-
-    def test_job_tags_and(self):
-        """Test using job tags with an and operator."""
+    def test_job_tags(self):
+        """Test using job tags."""
         # Use a unique tag.
         job_tags = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
         job = self.sim_backend.run(self.bell, job_tags=job_tags)
@@ -432,7 +406,7 @@ class TestIBMJobAttributes(IBMTestCase):
         no_rjobs_tags = [job_tags[0:1] + ["phantom_tags"], ["phantom_tag"]]
         for tags in no_rjobs_tags:
             rjobs = self.dependencies.provider.backend.jobs(
-                job_tags=tags, job_tags_operator="AND", start_datetime=self.last_week
+                job_tags=tags, start_datetime=self.last_week
             )
             self.assertEqual(
                 len(rjobs), 0, "Expected job {}, got {}".format(job.job_id(), rjobs)
@@ -443,7 +417,6 @@ class TestIBMJobAttributes(IBMTestCase):
             with self.subTest(tags=tags):
                 rjobs = self.dependencies.provider.backend.jobs(
                     job_tags=tags,
-                    job_tags_operator="AND",
                     start_datetime=self.last_week,
                 )
                 self.assertEqual(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Makes `provider.backend.jobs()` account level instead of provider level.
Adds `instance` to above function to help filter by h/g/p.


### Details and comments
Fixes #335 

