### PR TITLE
Mutate a circuit copy when id is replaced with delay

### DIFF
--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -482,9 +482,8 @@ class IBMBackend(Backend):
         if isinstance(shots, float):
             shots = int(shots)
 
-        circuits_to_run = circuits
         if not self.configuration().simulator:
-            circuits_to_run = self._deprecate_id_instruction(circuits)
+            circuits = self._deprecate_id_instruction(circuits)
 
         run_config_dict = self._get_run_config(
             qobj_header=header,
@@ -509,7 +508,7 @@ class IBMBackend(Backend):
         if sim_method and "method" not in run_config_dict:
             run_config_dict["method"] = sim_method
 
-        if isinstance(circuits_to_run, list):
+        if isinstance(circuits, list):
             chunk_size = None
             if hasattr(self.configuration(), "max_experiments"):
                 backend_max = self.configuration().max_experiments
@@ -521,10 +520,10 @@ class IBMBackend(Backend):
             elif max_circuits_per_job:
                 chunk_size = max_circuits_per_job
 
-            if chunk_size and len(circuits_to_run) > chunk_size:
+            if chunk_size and len(circuits) > chunk_size:
                 circuits_list = [
-                    circuits_to_run[x : x + chunk_size]
-                    for x in range(0, len(circuits_to_run), chunk_size)
+                    circuits[x : x + chunk_size]
+                    for x in range(0, len(circuits), chunk_size)
                 ]
                 return IBMCompositeJob(
                     backend=self,
@@ -535,7 +534,7 @@ class IBMBackend(Backend):
                     tags=job_tags,
                 )
 
-        qobj = assemble(circuits_to_run, self, **run_config_dict)
+        qobj = assemble(circuits, self, **run_config_dict)
 
         return self._submit_job(qobj, job_name, job_tags, live_data_enabled)
 
@@ -922,7 +921,7 @@ class IBMBackend(Backend):
                 :meth:`IBMBackend.run()<IBMBackend.run>`. Modified in-place.
 
         Returns:
-            A mutated copy of the original circuit where 'id' instructions are replaced with
+            A modified copy of the original circuit where 'id' instructions are replaced with
             'delay' instructions. A copy is used so the original circuit is not modified.
             If there are no 'id' instructions or 'delay' is not supported, return the original circuit.
         """

--- a/releasenotes/notes/backend-run-bug-08dfcfe4ffd0c6ff.yaml
+++ b/releasenotes/notes/backend-run-bug-08dfcfe4ffd0c6ff.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    :meth:`~qiskit_ibm_provider.IBMBackend.run` has been updated so circuits with 
+    ``id`` instructions that are replaced with ``delay`` instructions do not mutate
+    the original circuit. 

--- a/test/integration/test_backend.py
+++ b/test/integration/test_backend.py
@@ -14,7 +14,6 @@
 
 from datetime import timedelta, datetime
 from unittest import SkipTest
-from unittest import skip
 from unittest.mock import patch
 
 from qiskit import QuantumCircuit
@@ -178,11 +177,6 @@ class TestIBMBackend(IBMTestCase):
         self.assertTrue(backend_options["memory"])
         self.assertEqual(backend_options["foo"], "foo")
 
-    # TODO: Investigate why test fails
-    @skip(
-        "Known issue: currently fails with qiskit.providers.exceptions.BackendPropertyError: "
-        "'Could not find the desired property for sx)"
-    )
     def test_deprecate_id_instruction(self):
         """Test replacement of 'id' Instructions with 'Delay' instructions."""
 
@@ -210,9 +204,12 @@ class TestIBMBackend(IBMTestCase):
 
         with patch.object(self.backend, "configuration", return_value=config):
             with self.assertWarnsRegex(DeprecationWarning, r"'id' instruction"):
-                self.backend._deprecate_id_instruction(circuit_with_id)
+                mutated_circuit = self.backend._deprecate_id_instruction(
+                    circuit_with_id
+                )
 
-            self.assertEqual(circuit_with_id.count_ops(), {"delay": 3})
+            self.assertEqual(mutated_circuit[0].count_ops(), {"delay": 3})
+            self.assertEqual(circuit_with_id.count_ops(), {"id": 3})
 
 
 class TestIBMBackendService(IBMTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

fixes #334 

When the `id` instruction is replaced with the `delay` instruction the original circuit should not be mutated 

<img width="358" alt="Screen Shot 2022-04-27 at 10 16 27 AM" src="https://user-images.githubusercontent.com/20911417/165539469-5ef8d434-ef8a-4311-ad9c-fc70d259f0d2.png">


### Details and comments


