### PR TITLE
Update tox configuration to support tox 3.x and 4.x

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.1
 envlist = py37, py38, py39, py310, lint, docs
-skipsdist = True
+isolated_build = True
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the tox configuration to remove the sdist configuration flag which avoids the intermediate sdist creation as part of tox building the package under test in it's venv. It is replaced by the isolated_build option which configures tox to use a PEP 518/PEP 517 mechanism for building experiments. This mirrors the default behavior in tox 4.0.0. By making this change the tox.ini should be compatible with both tox 3.x.y and 4.x.y.

### Details and comments