### PR TITLE
Reset backend options to default in get_backend

### DIFF
--- a/qiskit_ibm_provider/ibm_provider.py
+++ b/qiskit_ibm_provider/ibm_provider.py
@@ -109,6 +109,10 @@ class IBMProvider(Provider):
 
         simulator_backend = provider.get_backend('ibmq_qasm_simulator')
 
+    IBMBackend's are uniquely identified by their name. If you invoke :meth:`get_backend()` twice,
+    you will get the same IBMBackend instance, and any previously updated options will be reset
+    to the default values.
+
     It is also possible to use the ``backend`` attribute to reference a backend.
     As an example, to retrieve the same backend from the example above::
 
@@ -660,6 +664,7 @@ class IBMProvider(Provider):
             )
         if not backends:
             raise QiskitBackendNotFoundError("No backend matches the criteria")
+        backends[0]._options = IBMBackend._default_options()
         return backends[0]
 
     def __repr__(self) -> str:

--- a/releasenotes/notes/reset_backend_options-f7e02c9bfff58213.yaml
+++ b/releasenotes/notes/reset_backend_options-f7e02c9bfff58213.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    ``IBMProvidef.get_backend()`` returns the backend with its default options. At the end of this
+    ``IBMProvider.get_backend()`` returns the backend with its default options. At the end of this
     .. code-block::
     
       backend1 = provider.get_backend("xxx")

--- a/releasenotes/notes/reset_backend_options-f7e02c9bfff58213.yaml
+++ b/releasenotes/notes/reset_backend_options-f7e02c9bfff58213.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    ``IBMProvidef.get_backend()`` returns the backend with its default options. At the end of this
+    example::
+    
+      backend1 = provider.get_backend("xxx")
+      backend1.options.shots = 100
+      backend2 = provider.get_backend("xxx")
+    
+    ``backend2.options.shots`` has the default value (4000). ``backend1.options.shots`` 
+    also has the default value, because backend1 and backend2 are the same instance.

--- a/releasenotes/notes/reset_backend_options-f7e02c9bfff58213.yaml
+++ b/releasenotes/notes/reset_backend_options-f7e02c9bfff58213.yaml
@@ -2,7 +2,7 @@
 fixes:
   - |
     ``IBMProvidef.get_backend()`` returns the backend with its default options. At the end of this
-    example::
+    .. code-block::
     
       backend1 = provider.get_backend("xxx")
       backend1.options.shots = 100

--- a/test/integration/test_ibm_provider.py
+++ b/test/integration/test_ibm_provider.py
@@ -202,6 +202,17 @@ class TestIBMProviderServices(IBMTestCase):
         backend = self.dependencies.provider.get_backend(name=self.backend_name)
         self.assertEqual(backend.name, self.backend_name)
 
+    def test_get_backend_options(self):
+        """Test resetting backend options when calling get_backend."""
+        backend1 = self.dependencies.provider.get_backend(name=self.backend_name)
+        self.assertEqual(backend1.options.shots, 4000)
+        backend1.options.shots = 100
+        self.assertEqual(backend1.options.shots, 100)
+        backend2 = self.dependencies.provider.get_backend(name=self.backend_name)
+        # When getting a backend, it has the default options. backend1 and backend2 are the same instance.
+        self.assertEqual(backend2.options.shots, 4000)
+        self.assertEqual(backend1.options.shots, 4000)
+
     def test_jobs_filter(self):
         """Test limit filters when accessing jobs from the provider."""
         num_jobs = PAGE_SIZE + 1

--- a/test/integration/test_ibm_provider.py
+++ b/test/integration/test_ibm_provider.py
@@ -204,14 +204,16 @@ class TestIBMProviderServices(IBMTestCase):
 
     def test_get_backend_options(self):
         """Test resetting backend options when calling get_backend."""
+        default_shots = 4000
         backend1 = self.dependencies.provider.get_backend(name=self.backend_name)
-        self.assertEqual(backend1.options.shots, 4000)
+        self.assertEqual(backend1.options.shots, default_shots)
         backend1.options.shots = 100
         self.assertEqual(backend1.options.shots, 100)
         backend2 = self.dependencies.provider.get_backend(name=self.backend_name)
-        # When getting a backend, it has the default options. backend1 and backend2 are the same instance.
-        self.assertEqual(backend2.options.shots, 4000)
-        self.assertEqual(backend1.options.shots, 4000)
+        # When getting a backend, it has the default options.
+        # backend1 and backend2 are the same instance.
+        self.assertEqual(backend2.options.shots, default_shots)
+        self.assertEqual(backend1.options.shots, default_shots)
 
     def test_jobs_filter(self):
         """Test limit filters when accessing jobs from the provider."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Reset `backend.options` to default in `IBMProvider.get_backend()`.


### Details and comments
See #489 - Please consider if you agree with my approach.
If we all agree, this should also be fixed in `qiskit_ibm_runtime`.

